### PR TITLE
Check if decl.parent.selector is not undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ module.exports = postcss.plugin('postcss-pxtorem', function (options) {
         css.eachDecl(function (decl, i) {
             if (propWhiteList.indexOf(decl.prop) === -1) return;
 
-            if (blacklistedSelector(selectorBlackList, decl.parent.selector)) return;
+            if (decl.parent.selector) {
+                if (blacklistedSelector(selectorBlackList, decl.parent.selector)) return;
+            }
 
             var rule = decl.parent;
             var value = decl.value;


### PR DESCRIPTION
I wrapped to checking blacklistedSelector call because I have error when I use:
selector_black_list: ['.specials-rotator__nav-item’],
and compile all styles in big project