### PR TITLE
Allow whitelisting of all properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Default:
 
 - `root_value` (Number) The root element font size.
 - `unit_precision` (Number) The decimal numbers to allow the REM units to grow to.
-- `prop_white_list` (Array) The properties that can change from px to rem.
+- `prop_white_list` (Array) The properties that can change from px to rem. `'*'` will change all properties.
 - `replace` (Boolean) replaces rules containing rems instead of adding fallbacks.
 - `media_query` (Boolean) Allow px to be converted in media queries.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Default:
 
 - `root_value` (Number) The root element font size.
 - `unit_precision` (Number) The decimal numbers to allow the REM units to grow to.
-- `prop_white_list` (Array) The properties that can change from px to rem. `'*'` will change all properties.
+- `prop_white_list` (Array) The properties that can change from px to rem. Alternatively, `'all'` will change all properties.
 - `replace` (Boolean) replaces rules containing rems instead of adding fallbacks.
 - `media_query` (Boolean) Allow px to be converted in media queries.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Default:
 
 - `root_value` (Number) The root element font size.
 - `unit_precision` (Number) The decimal numbers to allow the REM units to grow to.
-- `prop_white_list` (Array) The properties that can change from px to rem. Alternatively, `'all'` will change all properties.
+- `prop_white_list` (Array) The properties that can change from px to rem, or (String) `'all'` to change all properties.
 - `selector_black_list` (Array) The selectors to ignore and leave as px.
 - `replace` (Boolean) replaces rules containing rems instead of adding fallbacks.
 - `media_query` (Boolean) Allow px to be converted in media queries.

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = postcss.plugin('postcss-pxtorem', function (options) {
         };
 
         css.eachDecl(function (decl, i) {
-            if (propWhiteList.indexOf(decl.prop) === -1) return;
+            if (propWhiteList !== ['*'] && propWhiteList.indexOf(decl.prop) === -1) return;
 
             var rule = decl.parent;
             var value = decl.value;

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = postcss.plugin('postcss-pxtorem', function (options) {
         };
 
         css.eachDecl(function (decl, i) {
-            if (propWhiteList !== ['*'] && propWhiteList.indexOf(decl.prop) === -1) return;
+            if (propWhiteList !== 'all' && propWhiteList.indexOf(decl.prop) === -1) return;
 
             var rule = decl.parent;
             var value = decl.value;


### PR DESCRIPTION
I'd like to switch to use this in gulp from grunt on The Guardian, but currently we expect to remify all units. This PR would to enable that with `prop_white_list: 'all'`. 

This could be particularly useful used with the new `selectorBlackList`. 

Incidentally, interested to know why you didn't want to whitelist all props by default?