### PR TITLE
fix: `calc` expressions need units to work properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ function createPxReplace(rootValue, unitPrecision, minPixelValue) {
     const pixels = parseFloat($1);
     if (pixels < minPixelValue) return m;
     const fixedVal = toFixed(pixels / rootValue, unitPrecision);
-    return fixedVal === 0 ? "0" : fixedVal + "rem";
+    // `calc` expressions need units to work properly
+    return fixedVal + "rem";
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "postcss-pxtorem",
       "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
fix #81