### PR TITLE
fix: #93 exclude function parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = (options = {}) => {
         exclude &&
         ((type.isFunction(exclude) && exclude(filePath)) ||
           (type.isString(exclude) && filePath.indexOf(exclude) !== -1) ||
-          filePath.match(exclude) !== null)
+          (!type.isFunction(exclude) && filePath.match(exclude) !== null))
       ) {
         isExcludeFile = true;
       } else {


### PR DESCRIPTION
I've attached simple fix to issue I mentioned https://github.com/cuth/postcss-pxtorem/issues/93.

Change exclude covert logics, when exclude option value is a function, it will not exec the following code

```js
filePath.match(exclude) !== null
```