### PR TITLE
feat: Support custom convert px unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Default:
     - If value is function, you can use exclude function to return a true and the file will be ignored.
         - the callback will pass the file path as  a parameter, it should returns a Boolean result.
         - `function (file) { return file.indexOf('exclude') !== -1; }`
+- `unit` (String) Set the default unit to convert, default is `px`.
 
 ### Use with gulp-postcss and autoprefixer
 

--- a/index.js
+++ b/index.js
@@ -1,39 +1,39 @@
-const pxRegex = require('./lib/pixel-unit-regex');
-const filterPropList = require('./lib/filter-prop-list');
-const type = require('./lib/type');
+const pxRegex = require("./lib/pixel-unit-regex");
+const filterPropList = require("./lib/filter-prop-list");
+const type = require("./lib/type");
 
 const defaults = {
   rootValue: 16,
   unitPrecision: 5,
   selectorBlackList: [],
-  propList: ['font', 'font-size', 'line-height', 'letter-spacing'],
+  propList: ["font", "font-size", "line-height", "letter-spacing"],
   replace: true,
   mediaQuery: false,
   minPixelValue: 0,
   exclude: null,
-  unit: 'px',
+  unit: "px",
 };
 
 const legacyOptions = {
-  root_value: 'rootValue',
-  unit_precision: 'unitPrecision',
-  selector_black_list: 'selectorBlackList',
-  prop_white_list: 'propList',
-  media_query: 'mediaQuery',
-  propWhiteList: 'propList',
+  root_value: "rootValue",
+  unit_precision: "unitPrecision",
+  selector_black_list: "selectorBlackList",
+  prop_white_list: "propList",
+  media_query: "mediaQuery",
+  propWhiteList: "propList",
 };
 
 function convertLegacyOptions(options) {
-  if (typeof options !== 'object') return;
+  if (typeof options !== "object") return;
   if (
-    ((typeof options['prop_white_list'] !== 'undefined' &&
-      options['prop_white_list'].length === 0) ||
-      (typeof options.propWhiteList !== 'undefined' &&
+    ((typeof options["prop_white_list"] !== "undefined" &&
+      options["prop_white_list"].length === 0) ||
+      (typeof options.propWhiteList !== "undefined" &&
         options.propWhiteList.length === 0)) &&
-    typeof options.propList === 'undefined'
+    typeof options.propList === "undefined"
   ) {
-    options.propList = ['*'];
-    delete options['prop_white_list'];
+    options.propList = ["*"];
+    delete options["prop_white_list"];
     delete options.propWhiteList;
   }
   Object.keys(legacyOptions).forEach((key) => {
@@ -50,7 +50,7 @@ function createPxReplace(rootValue, unitPrecision, minPixelValue) {
     const pixels = parseFloat($1);
     if (pixels < minPixelValue) return m;
     const fixedVal = toFixed(pixels / rootValue, unitPrecision);
-    return fixedVal === 0 ? '0' : fixedVal + 'rem';
+    return fixedVal === 0 ? "0" : fixedVal + "rem";
   };
 }
 
@@ -65,9 +65,9 @@ function declarationExists(decls, prop, value) {
 }
 
 function blacklistedSelector(blacklist, selector) {
-  if (typeof selector !== 'string') return;
+  if (typeof selector !== "string") return;
   return blacklist.some((regex) => {
-    if (typeof regex === 'string') {
+    if (typeof regex === "string") {
       return selector.indexOf(regex) !== -1;
     }
     return selector.match(regex);
@@ -75,7 +75,7 @@ function blacklistedSelector(blacklist, selector) {
 }
 
 function createPropListMatcher(propList) {
-  const hasWild = propList.indexOf('*') > -1;
+  const hasWild = propList.indexOf("*") > -1;
   const matchAll = hasWild && propList.length === 1;
   const lists = {
     exact: filterPropList.exact(propList),
@@ -125,7 +125,7 @@ module.exports = (options = {}) => {
   let isExcludeFile = false;
   let pxReplace;
   return {
-    postcssPlugin: 'postcss-pxtorem',
+    postcssPlugin: "postcss-pxtorem",
     Once(css) {
       const filePath = css.source.input.file;
       if (
@@ -140,7 +140,7 @@ module.exports = (options = {}) => {
       }
 
       const rootValue =
-        typeof opts.rootValue === 'function'
+        typeof opts.rootValue === "function"
           ? opts.rootValue(css.source.input)
           : opts.rootValue;
       pxReplace = createPxReplace(
@@ -173,7 +173,7 @@ module.exports = (options = {}) => {
     AtRule(atRule) {
       if (isExcludeFile) return;
 
-      if (opts.mediaQuery && atRule.name === 'media') {
+      if (opts.mediaQuery && atRule.name === "media") {
         if (atRule.params.indexOf(opts.unit) === -1) return;
         atRule.params = atRule.params.replace(pxRegex(opts.unit), pxReplace);
       }

--- a/index.js
+++ b/index.js
@@ -1,41 +1,42 @@
-const pxRegex = require("./lib/pixel-unit-regex");
-const filterPropList = require("./lib/filter-prop-list");
-const type = require("./lib/type");
+const pxRegex = require('./lib/pixel-unit-regex');
+const filterPropList = require('./lib/filter-prop-list');
+const type = require('./lib/type');
 
 const defaults = {
   rootValue: 16,
   unitPrecision: 5,
   selectorBlackList: [],
-  propList: ["font", "font-size", "line-height", "letter-spacing"],
+  propList: ['font', 'font-size', 'line-height', 'letter-spacing'],
   replace: true,
   mediaQuery: false,
   minPixelValue: 0,
-  exclude: null
+  exclude: null,
+  unit: 'px',
 };
 
 const legacyOptions = {
-  root_value: "rootValue",
-  unit_precision: "unitPrecision",
-  selector_black_list: "selectorBlackList",
-  prop_white_list: "propList",
-  media_query: "mediaQuery",
-  propWhiteList: "propList"
+  root_value: 'rootValue',
+  unit_precision: 'unitPrecision',
+  selector_black_list: 'selectorBlackList',
+  prop_white_list: 'propList',
+  media_query: 'mediaQuery',
+  propWhiteList: 'propList',
 };
 
 function convertLegacyOptions(options) {
-  if (typeof options !== "object") return;
+  if (typeof options !== 'object') return;
   if (
-    ((typeof options["prop_white_list"] !== "undefined" &&
-      options["prop_white_list"].length === 0) ||
-      (typeof options.propWhiteList !== "undefined" &&
+    ((typeof options['prop_white_list'] !== 'undefined' &&
+      options['prop_white_list'].length === 0) ||
+      (typeof options.propWhiteList !== 'undefined' &&
         options.propWhiteList.length === 0)) &&
-    typeof options.propList === "undefined"
+    typeof options.propList === 'undefined'
   ) {
-    options.propList = ["*"];
-    delete options["prop_white_list"];
+    options.propList = ['*'];
+    delete options['prop_white_list'];
     delete options.propWhiteList;
   }
-  Object.keys(legacyOptions).forEach(key => {
+  Object.keys(legacyOptions).forEach((key) => {
     if (Reflect.has(options, key)) {
       options[legacyOptions[key]] = options[key];
       delete options[key];
@@ -49,7 +50,7 @@ function createPxReplace(rootValue, unitPrecision, minPixelValue) {
     const pixels = parseFloat($1);
     if (pixels < minPixelValue) return m;
     const fixedVal = toFixed(pixels / rootValue, unitPrecision);
-    return fixedVal === 0 ? "0" : fixedVal + "rem";
+    return fixedVal === 0 ? '0' : fixedVal + 'rem';
   };
 }
 
@@ -60,13 +61,13 @@ function toFixed(number, precision) {
 }
 
 function declarationExists(decls, prop, value) {
-  return decls.some(decl => decl.prop === prop && decl.value === value);
+  return decls.some((decl) => decl.prop === prop && decl.value === value);
 }
 
 function blacklistedSelector(blacklist, selector) {
-  if (typeof selector !== "string") return;
-  return blacklist.some(regex => {
-    if (typeof regex === "string") {
+  if (typeof selector !== 'string') return;
+  return blacklist.some((regex) => {
+    if (typeof regex === 'string') {
       return selector.indexOf(regex) !== -1;
     }
     return selector.match(regex);
@@ -74,7 +75,7 @@ function blacklistedSelector(blacklist, selector) {
 }
 
 function createPropListMatcher(propList) {
-  const hasWild = propList.indexOf("*") > -1;
+  const hasWild = propList.indexOf('*') > -1;
   const matchAll = hasWild && propList.length === 1;
   const lists = {
     exact: filterPropList.exact(propList),
@@ -84,31 +85,31 @@ function createPropListMatcher(propList) {
     notExact: filterPropList.notExact(propList),
     notContain: filterPropList.notContain(propList),
     notStartWith: filterPropList.notStartWith(propList),
-    notEndWith: filterPropList.notEndWith(propList)
+    notEndWith: filterPropList.notEndWith(propList),
   };
-  return prop => {
+  return (prop) => {
     if (matchAll) return true;
     return (
       (hasWild ||
         lists.exact.indexOf(prop) > -1 ||
-        lists.contain.some(function(m) {
+        lists.contain.some(function (m) {
           return prop.indexOf(m) > -1;
         }) ||
-        lists.startWith.some(function(m) {
+        lists.startWith.some(function (m) {
           return prop.indexOf(m) === 0;
         }) ||
-        lists.endWith.some(function(m) {
+        lists.endWith.some(function (m) {
           return prop.indexOf(m) === prop.length - m.length;
         })) &&
       !(
         lists.notExact.indexOf(prop) > -1 ||
-        lists.notContain.some(function(m) {
+        lists.notContain.some(function (m) {
           return prop.indexOf(m) > -1;
         }) ||
-        lists.notStartWith.some(function(m) {
+        lists.notStartWith.some(function (m) {
           return prop.indexOf(m) === 0;
         }) ||
-        lists.notEndWith.some(function(m) {
+        lists.notEndWith.some(function (m) {
           return prop.indexOf(m) === prop.length - m.length;
         })
       )
@@ -124,7 +125,7 @@ module.exports = (options = {}) => {
   let isExcludeFile = false;
   let pxReplace;
   return {
-    postcssPlugin: "postcss-pxtorem",
+    postcssPlugin: 'postcss-pxtorem',
     Once(css) {
       const filePath = css.source.input.file;
       if (
@@ -139,26 +140,26 @@ module.exports = (options = {}) => {
       }
 
       const rootValue =
-        typeof opts.rootValue === "function"
+        typeof opts.rootValue === 'function'
           ? opts.rootValue(css.source.input)
           : opts.rootValue;
       pxReplace = createPxReplace(
         rootValue,
         opts.unitPrecision,
-        opts.minPixelValue
+        opts.minPixelValue,
       );
     },
     Declaration(decl) {
       if (isExcludeFile) return;
 
       if (
-        decl.value.indexOf("px") === -1 ||
+        decl.value.indexOf(opts.unit) === -1 ||
         !satisfyPropList(decl.prop) ||
         blacklistedSelector(opts.selectorBlackList, decl.parent.selector)
       )
         return;
 
-      const value = decl.value.replace(pxRegex, pxReplace);
+      const value = decl.value.replace(pxRegex(opts.unit), pxReplace);
 
       // if rem unit already exists, do not add or replace
       if (declarationExists(decl.parent, decl.prop, value)) return;
@@ -172,11 +173,11 @@ module.exports = (options = {}) => {
     AtRule(atRule) {
       if (isExcludeFile) return;
 
-      if (opts.mediaQuery && atRule.name === "media") {
-        if (atRule.params.indexOf("px") === -1) return;
-        atRule.params = atRule.params.replace(pxRegex, pxReplace);
+      if (opts.mediaQuery && atRule.name === 'media') {
+        if (atRule.params.indexOf(opts.unit) === -1) return;
+        atRule.params = atRule.params.replace(pxRegex(opts.unit), pxReplace);
       }
-    }
+    },
   };
 };
 module.exports.postcss = true;

--- a/lib/pixel-unit-regex.js
+++ b/lib/pixel-unit-regex.js
@@ -6,4 +6,8 @@
 // Any digit followed by px
 // !singlequotes|!doublequotes|!url()|pixelunit
 
-module.exports = /"[^"]+"|'[^']+'|url\([^)]+\)|var\([^)]+\)|(\d*\.?\d+)px/g;
+module.exports = (unit) =>
+  new RegExp(
+    `"[^"]+"|'[^']+'|url\\([^)]+\\)|var\\([^)]+\\)|(\\d*\\.?\\d+)${unit}`,
+    'g',
+  );

--- a/spec/pxtorem-spec.js
+++ b/spec/pxtorem-spec.js
@@ -540,4 +540,18 @@ describe("exclude", function() {
     }).css;
     expect(processed).toBe(basicCSS);
   });
+
+  it("should only replace properties in the prop list with wildcard", function() {
+    var input =
+      "h1 { margin: 0 0 20rpx; font-size: 32rpx; line-height: 1.2; letter-spacing: 1rpx; width: 30px;}";
+    var output =
+      "h1 { margin: 0 0 1.25rem; font-size: 2rem; line-height: 1.2; letter-spacing: 0.0625rem; width: 30px;}";
+    var options = {
+      unit: "rpx",
+      propList: ["*"]
+    };
+    var processed = postcss(pxtorem(options)).process(input).css;
+
+    expect(processed).toBe(output);
+  });
 });


### PR DESCRIPTION
With this feature, you can use it selectively without worrying about conflicts. For example, I use rpx as the unit.

```css
.test {
  height: 32rpx;
}
```