### PR TITLE
Adjust handling of zero values to preserve CSS clamp() compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function createPxReplace(rootValue, unitPrecision, minPixelValue) {
     const pixels = parseFloat($1);
     if (pixels < minPixelValue) return m;
     const fixedVal = toFixed(pixels / rootValue, unitPrecision);
-    return fixedVal === 0 ? "0" : fixedVal + "rem";
+    return fixedVal + "rem";
   };
 }
 


### PR DESCRIPTION
This change addresses an issue where CSS clamp() functions were breaking because they require a unit to clamp properly. Removing this conditional ensures that the unit is included even when the value is zero, allowing clamp() functions to work correctly with zero values.