### PR TITLE
fix: exclude verify type of RegExp

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = (options = {}) => {
         exclude &&
         ((type.isFunction(exclude) && exclude(filePath)) ||
           (type.isString(exclude) && filePath.indexOf(exclude) !== -1) ||
-          filePath.match(exclude) !== null)
+          (type.isRegExp(exclude) && filePath.match(exclude) !== null))
       ) {
         isExcludeFile = true;
       } else {

--- a/lib/type.js
+++ b/lib/type.js
@@ -12,7 +12,8 @@ const types = [
   "Number",
   "Function",
   "Symbol",
-  "Object"
+  "Object",
+  "RegExp"
 ];
 
 module.exports = types.reduce((acc, str) => {


### PR DESCRIPTION
add exclude verify type of RegExp:
if exclude type is Function, it has a bug
eg:
postCssPxToRem({
  exclude: (filePath) => {
    const reg = /src\/pages\/m|src\/components\/m|share\/components\/m/;
    return !reg.test(filePath);
  },
})
if we got a filePath: '/project/src/components/m/Button.scss', exclude(filePath) return false, but isExcludeFile will be true;
because filePath.match(exclude) !== null

if we pass a function to math, it will be potential risks:
console.log('abc'.match(() => { const reg = /a|b|c/; }))